### PR TITLE
Add full list of Steam OS handhelds

### DIFF
--- a/FAQ/Markdown/Comparisons.md
+++ b/FAQ/Markdown/Comparisons.md
@@ -13,3 +13,4 @@ Source: [Handhelds](https://docs.google.com/spreadsheets/d/1irg60f9qsZOkhp0cwOU7
 ## Consoles
 - PS5
 - Xbox Series S/X
+- Nintendo Switch 2

--- a/FAQ/Markdown/Comparisons.md
+++ b/FAQ/Markdown/Comparisons.md
@@ -5,11 +5,10 @@
 ## Laptop
 
 ## Handhelds
-- Asus ROG Ally (X)
-- Lenovo Legion Go
-- Playstation Portal
-- MSI Claw
-- Nintendo Switch (OLED / 2)
+See the complete list of handhels that run Steam OS [here](https://docs.google.com/spreadsheets/d/1j7h38ko9cAPgO0R-n04JKsgZHJp5LFHyh-mO7aHfkAU/edit?usp=sharing)
+
+Source: [Handhelds](https://docs.google.com/spreadsheets/d/1irg60f9qsZOkhp0cwOU7Cy4rJQeyusEUzTNQzhoTYTU/edit?usp=sharing) 
+- Filter: OS contains the words Steam 
 
 ## Consoles
 - PS5


### PR DESCRIPTION
- Added link to spreadsheet with full list of Steam OS compatible handsets.
- Moved Nintendo to Consoles.
- Removed other links.